### PR TITLE
Improvement on README examples to avoid context confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sample Alert
 ```
 showPlatformDialog(
   context: context,
-  builder: (_) => BasicDialogAlert(
+  builder: (context) => BasicDialogAlert(
     title: Text("Current Location Not Available"),
     content:
         Text("Your current location cannot be determined at this time."),
@@ -40,7 +40,7 @@ Sample Confirmation
 ```
 showPlatformDialog(
   context: context,
-  builder: (_) => BasicDialogAlert(
+  builder: (context) => BasicDialogAlert(
     title: Text("Discard draft?"),
     content: Text("Action cannot be undone."),
     actions: <Widget>[
@@ -70,7 +70,7 @@ Sample List
 ```
 showPlatformDialog(
   context: context,
-  builder: (_) => BasicDialogAlert(
+  builder: (context) => BasicDialogAlert(
     title: Text("Select account"),
     content: Container(
       height: 200,


### PR DESCRIPTION
Currently on the examples on the readme, the code omit the context variable on the builder methods.

If someone copy and paste one example (like I did 😅) to test, this code can lead to unexpected behaviour as the `Navigator.pop(context)` will use the `context` variable from the outer scope, potentially popping the wrong navigation.

Sending this PR with the hopes to avoid confusion in the future!

Thanks for this awesome package!